### PR TITLE
Don't unconditionally clobber any existing JSZip variable.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xlsx.js",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": "Stephen Hardy",
   "description": "Convert data in base64 XLSX files into JavaScript objects - and back!",
   "contributors": [ 

--- a/xlsx.js
+++ b/xlsx.js
@@ -1,6 +1,5 @@
-var JSZip = null
-if (typeof require === 'function') {
-	JSZip = require('node-zip');
+if ((typeof JSZip === 'undefined' || !JSZip) && typeof require === 'function') {
+	var JSZip = require('node-zip');
 }
 
 //----------------------------------------------------------
@@ -9,7 +8,7 @@ if (typeof require === 'function') {
 // https://raw.github.com/stephen-hardy/xlsx.js/master/LICENSE.txt
 //----------------------------------------------------------
 function xlsx(file) { 
-	'use strict'; // v2.3.0
+	'use strict'; // v2.3.1
 
 	var defaultFontName = 'Calibri';
 	var defaultFontSize = 11;


### PR DESCRIPTION
This fixes issues where a browser had already loaded jszip.js but isn't
using require. This also bumps the version to 2.3.1.
