### PR TITLE
Tell Excel to refresh formula calculations as soon as the file is opened...

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -455,7 +455,7 @@ function xlsx(file) {
 		xl.file('workbook.xml', '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
 			+ '<fileVersion appName="xl" lastEdited="5" lowestEdited="5" rupBuild="9303"/><workbookPr defaultThemeVersion="124226"/><bookViews><workbookView '
 			+ (file.activeWorksheet ? 'activeTab="' + file.activeWorksheet + '" ' : '') + 'xWindow="480" yWindow="60" windowWidth="18195" windowHeight="8505"/></bookViews><sheets>'
-			+ worksheets.join('') + '</sheets><calcPr calcId="145621"/></workbook>');
+			+ worksheets.join('') + '</sheets><calcPr fullCalcOnLoad="1"/></workbook>');
 
 		processTime = Date.now() - processTime;
 		zipTime = Date.now();


### PR DESCRIPTION
....

If a formula is provided by JS, then JS should not be expected to also provide the initial result of that formula in order for the spreadsheet to look correct on open. 

The attribute fullCalcOnLoad="1" tells excel that all formulas should be evaluated on open.

Solution taken from:
http://stackoverflow.com/a/18447197/1413853
