### PR TITLE
Date.now is not supported in IE

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -8,6 +8,11 @@ if ((typeof JSZip === 'undefined' || !JSZip) && typeof require === 'function') {
 	var JSZip = require('node-zip');
 }
 
+// for < IE9
+if (!Date.now) {
+  Date.now = function() { return new Date().valueOf() }
+}
+
 function xlsx(file) { 
 	'use strict'; // v2.3.2
 


### PR DESCRIPTION
This little fix permits to make xlsx.js work with IE8
