### PR TITLE
Cell Width, Text Wrap, Font/Background Color, Table Options

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -183,7 +183,7 @@ function xlsx(file) {
 						fontColor: cell.fontColor
 					};
 					colWidth = cell.width || 0;
-					if (val && typeof val === 'string' && (isNaN(parseFloat(n)) || !isFinite(n) )) { 
+					if (val && typeof val === 'string' && (isNaN(parseFloat(val)) || !isFinite(val) )) { 
 						// If value is string, and not string of just a number, place a sharedString reference instead of the value
 						val = escapeXML(val);
 						sharedStrings[1]++; // Increment total count, unique count derived from sharedStrings[0].length


### PR DESCRIPTION
I noticed that the library only outputs column widths if autowidth is set for the column, and ignores any auto calculated widths. This fixes that issue by always writing the column, and also gives the user greater control by allowing an optional cell width property. Also added a wrapText (boolean) cell property to support cell text wrapping.
Added table options, worksheet.table can still be specified as boolean, or object with optionional topLeftRow, topLeftColumn, style, stripeColumns and stripRows properties (for example for a table starting at A3 rather than A1, {topLeftRow: 3, topLeftColumn:0, style:'tableStyleNone'}
Added support for background fill via backgroundColor property
Added support for font color via the fontColor property
Fixed bug with string detection, " " was not detected as a string (isFinite returned true)
