### PR TITLE
Allow to force cell as text

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -178,7 +178,7 @@ function xlsx(file) {
 						formatCode: cell.formatCode || 'General'
 					};
 					colWidth = 0;
-					if (val && typeof val === 'string' && !isFinite(val)) { 
+					if ((cell.type && cell.type === 'text') || (val && typeof val === 'string' && !isFinite(val))) { 
 						// If value is string, and not string of just a number, place a sharedString reference instead of the value
 						val = escapeXML(val);
 						sharedStrings[1]++; // Increment total count, unique count derived from sharedStrings[0].length


### PR DESCRIPTION
Allow to force a cell as text, even it contains a number like "06789".

```
worksheets: [{
  data: [
    { value: '06789', type: 'text' }
  ]
}]
```